### PR TITLE
fix: alias records has no TTL, breaks logging.

### DIFF
--- a/src/route53_ddns/route53_interface.py
+++ b/src/route53_ddns/route53_interface.py
@@ -66,7 +66,7 @@ def get_current_ip(zone_id: str, record_name: str) -> Optional[str]:
 
     matched = None
     for record in zone_records["ResourceRecordSets"]:
-        logger.info(f"Found record of type {record['Type']} with ttl {record['TTL']} named {record['Name']}")
+        logger.info(f"Found record of type {record['Type']} named {record['Name']}")
 
         if record["Name"] == f"{record_name}.":
             matched = record


### PR DESCRIPTION
When the domain in route53 has an "alias" type record, the logging breaks as it there is no "TTL" key "alias" records.
